### PR TITLE
Use readthedocs-custom-steps for install packages

### DIFF
--- a/.readthedocs-custom-steps.yml
+++ b/.readthedocs-custom-steps.yml
@@ -1,0 +1,3 @@
+# .readthedocs-custom-steps.yml
+steps:
+- echo "Custom steps to produce HTML in $SITE_DIR here ..."

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,5 @@
 # .readthedocs.yml
 version: 2
-mkdocs: {}  # tell readthedocs to use mkdocs
 submodules:
   include:
      - pyvista

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+# .readthedocs.yml
+version: 2
+mkdocs: {}  # tell readthedocs to use mkdocs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt  # must contain "readthedocs-custom-steps"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,10 @@
 # .readthedocs.yml
 version: 2
 mkdocs: {}  # tell readthedocs to use mkdocs
+submodules:
+  include:
+     - pyvista
+  recursive: true
 python:
   version: 3.7
   install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest-sphinx
 sphinx-notfound-page>=0.3.0
 sphinx-copybutton
 sphinx-gallery>=0.4.0
+readthedocs-custom-steps


### PR DESCRIPTION
Subject: Use readthedocs-custom-steps for install packages

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Use readthedocs-custom-steps for install packages
### Detail
- None

### Relates
- https://pypi.org/project/readthedocs-custom-steps/
