### PR TITLE
🗑 Remove autodoc_mock_imports

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -25,7 +25,6 @@ os.environ["PYVISTA_USE_PANEL"] = "true"
 os.environ["PYVISTA_PLOT_THEME"] = "document"
 os.environ["PYVISTA_AUTO_CLOSE"] = "false"
 
-autodoc_mock_imports = ["vtk"]
 shutil.rmtree("pyvista/docs/examples", ignore_errors=True)
 shutil.copytree("locale/examples", "pyvista/docs/examples")
 shutil.rmtree("pyvista/docs/images/auto-generated", ignore_errors=True)


### PR DESCRIPTION
Subject: :wastebasket: Remove autodoc_mock_imports

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Remove autodoc_mock_imports

### Detail
- None

### Relates
- None
